### PR TITLE
Fix the syntax for Type

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -136,11 +136,11 @@ syntax keyword swiftStructure
       \ struct
       \ enum
 
-syntax region swiftTypeWrapper start="\v:\s*" end="\v[^\w]" contains=swiftString,swiftType,swiftGenericsWrapper transparent oneline
+syntax region swiftTypeWrapper start="\v:\s*" end="\v[^\w]" contains=swiftString,swiftBoolean,swiftNumber,swiftType,swiftGenericsWrapper transparent oneline
 syntax region swiftGenericsWrapper start="\v\<" end="\v\>" contains=swiftType transparent oneline
 syntax region swiftLiteralWrapper start="\v\=\s*" skip="\v[^\[\]]\(\)" end="\v(\[\]|\(\))" contains=swiftType transparent oneline
 syntax region swiftReturnWrapper start="\v-\>\s*" end="\v(\{|$)" contains=swiftType transparent oneline
-syntax match swiftType "\v\w+" contained containedin=swiftGenericsWrapper,swiftTypeWrapper,swiftLiteralWrapper,swiftGenericsWrapper
+syntax match swiftType "\v\u\w*" contained containedin=swiftGenericsWrapper,swiftTypeWrapper,swiftLiteralWrapper,swiftGenericsWrapper
 
 syntax keyword swiftImports import
 


### PR DESCRIPTION
## before

![before](https://cloud.githubusercontent.com/assets/629993/3943967/6685395c-25dc-11e4-8eb9-47390bf20c56.png)
- Argument of the function is also recognized as a `Type`
- The color of `Number` of the argument is inappropriate
## after

![after](https://cloud.githubusercontent.com/assets/629993/3943968/6997bac0-25dc-11e4-96cc-d4ab3da0990e.png)
