### PR TITLE
Remove oneline argument from swiftString

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -24,7 +24,7 @@ syntax region swiftComment start="\v^\s*\/\*" end="\v\*\/"
 
 " Literals
 " Strings
-syntax region swiftString start=/"/ skip=/\\"/ end=/"/ oneline contains=swiftInterpolatedWrapper
+syntax region swiftString start=/"/ skip=/\\"/ end=/"/ contains=swiftInterpolatedWrapper
 syntax region swiftInterpolatedWrapper start="\v\\\(\s*" end="\v\s*\)" contained containedin=swiftString contains=swiftInterpolatedString
 syntax match swiftInterpolatedString "\v\w+(\(\))?" contained containedin=swiftInterpolatedWrapper
 


### PR DESCRIPTION
This should fix https://github.com/Keithbsmiley/swift.vim/issues/28
