### PR TITLE
Massively update indentation

### DIFF
--- a/indent/swift.vim
+++ b/indent/swift.vim
@@ -114,14 +114,11 @@ function! SwiftIndent(lnum)
 
         if line =~ "}.*{"
           let openingBracket = searchpair("{", "", "}", "bWn")
-
           return indent(openingBracket)
         endif
 
         if numCloseParens > numOpenParens
-
-          normal! mi
-          normal! k
+          normal! mik
           let openingParen = searchpair("(", "", ")", "bWn")
           normal! `i
           return indent(openingParen)


### PR DESCRIPTION
This is a massive change to how indentation works. This removes the previous function and replaces it with a new one. Originally I wanted to rely on `cindent` more here but after spending some time with it, it really isn't right for swift. Still, falling back to it is better than handling all of the cases. This could still use some massive refactoring but I want it to get tested a little first.
