### PR TITLE
Update swift keywords and attributes for Swift 2

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -61,10 +61,12 @@ syntax keyword swiftKeywords
       \ as
       \ break
       \ case
+      \ catch
       \ class
       \ continue
       \ convenience
       \ default
+      \ defer
       \ deinit
       \ didSet
       \ do
@@ -76,6 +78,7 @@ syntax keyword swiftKeywords
       \ for
       \ func
       \ get
+      \ guard
       \ if
       \ import
       \ in
@@ -96,6 +99,7 @@ syntax keyword swiftKeywords
       \ private
       \ protocol
       \ public
+      \ repeat
       \ required
       \ return
       \ self
@@ -104,6 +108,8 @@ syntax keyword swiftKeywords
       \ subscript
       \ super
       \ switch
+      \ throws
+      \ try
       \ typealias
       \ unowned
       \ unowned(safe)
@@ -119,17 +125,21 @@ syntax keyword swiftAttributes
       \ @assignment
       \ @autoclosure
       \ @availability
+      \ @convention
       \ @exported
       \ @IBAction
       \ @IBDesignable
       \ @IBInspectable
       \ @IBOutlet
+      \ @nonobjc
       \ @noreturn
       \ @NSApplicationMain
       \ @NSCopying
       \ @NSManaged
       \ @objc
+      \ @testable
       \ @UIApplicationMain
+      \ @warn_unused_result
 
 syntax keyword swiftStructure
       \ struct


### PR DESCRIPTION
This adds new syntax keywords introduced in Swift 2.0 in the
`swiftKeywords` and `swiftAttributes` syntax groups.

Feel free to wait for Swift 2.0 to become fully stable before merging this, and I'll continue to update this pull request with any changes introduced in subsequent Swift 2.0 betas.