### PR TITLE
Fix highlighting for underscore separated numbers

### DIFF
--- a/example/example.swift
+++ b/example/example.swift
@@ -61,11 +61,14 @@ comment
 0o567 // octal
 0o5689 // broken octal
 
-1_000_000 // underscore separated million
-1_000_0000_ // broken underscore separated number
-1_000_000.000_000_1  // just over one million
-1_18181888_2.1       // still valid according to swift repl
-1_18181888_2.1.1       // broken underscore padded double
+1_000_000                // underscore separated million
+1_000_0000_              // broken underscore separated number
+1_000_0000.              // broken underscore separated float
+1_000_000.000_000_1      // just over one million
+1_18181888_2.1.1         // broken underscore padded double
+1_18181888_2.1           // valid according to swift repl
+1_0_0                    // valid 100
+1_____0.2________20___2  // also valid 10.2202
 
 // Operators
 ~

--- a/example/example.swift
+++ b/example/example.swift
@@ -61,6 +61,12 @@ comment
 0o567 // octal
 0o5689 // broken octal
 
+1_000_000 // underscore separated million
+1_000_0000_ // broken underscore separated number
+1_000_000.000_000_1  // just over one million
+1_18181888_2.1       // still valid according to swift repl
+1_18181888_2.1.1       // broken underscore padded double
+
 // Operators
 ~
 !

--- a/example/example.swift
+++ b/example/example.swift
@@ -68,7 +68,9 @@ comment
 1_18181888_2.1.1         // broken underscore padded double
 1_18181888_2.1           // valid according to swift repl
 1_0_0                    // valid 100
+1_0_000.2                // valid 10000.2
 1_____0.2________20___2  // also valid 10.2202
+4__3.2_33_33             // valid 43.233
 
 // Operators
 ~

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -23,6 +23,7 @@ syntax match swiftInterpolatedString "\v\w+(\(\))?" contained containedin=swiftI
 
 " Numbers
 syntax match swiftNumber "\v<\d+>"
+syntax match swiftNumber "\v<(\d+_\d+)+(\.\d+(_\d+)*)?>"
 syntax match swiftNumber "\v<\d+\.\d+>"
 syntax match swiftNumber "\v<\d*\.?\d+([Ee]-?)?\d+>"
 syntax match swiftNumber "\v<0x\x+([Pp]-?)?\x+>"

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -23,7 +23,7 @@ syntax match swiftInterpolatedString "\v\w+(\(\))?" contained containedin=swiftI
 
 " Numbers
 syntax match swiftNumber "\v<\d+>"
-syntax match swiftNumber "\v<(\d+_+\d+)+(\.\d+(_+\d+)*)?>"
+syntax match swiftNumber "\v<(\d+_+)+\d+(\.\d+(_+\d+)*)?>"
 syntax match swiftNumber "\v<\d+\.\d+>"
 syntax match swiftNumber "\v<\d*\.?\d+([Ee]-?)?\d+>"
 syntax match swiftNumber "\v<0x\x+([Pp]-?)?\x+>"

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -23,7 +23,7 @@ syntax match swiftInterpolatedString "\v\w+(\(\))?" contained containedin=swiftI
 
 " Numbers
 syntax match swiftNumber "\v<\d+>"
-syntax match swiftNumber "\v<(\d+_\d+)+(\.\d+(_\d+)*)?>"
+syntax match swiftNumber "\v<(\d+_+\d+)+(\.\d+(_+\d+)*)?>"
 syntax match swiftNumber "\v<\d+\.\d+>"
 syntax match swiftNumber "\v<\d*\.?\d+([Ee]-?)?\d+>"
 syntax match swiftNumber "\v<0x\x+([Pp]-?)?\x+>"


### PR DESCRIPTION
"The Basics" chapter of the official "The Swift Programming Language"
book states that you can pad numbers with underscores to help
readability.

This commit also handles the case where underscore padded numbers can
also contain a period (i.e., underscore padded float/double)

Additionally, added some underscore padded numbers in example/swift.vim
for testing purposes.

Fixes #51