### PR TITLE
Highlight @available/#available attributes

### DIFF
--- a/example/example.swift
+++ b/example/example.swift
@@ -246,6 +246,7 @@ lazy var foo : String
 client.host = "example.com"
 client.pathPrefix = "/foo/"
 
+@available(*, unavailable, renamed="bar", introduced=1.0, deprecated=2.2, message="hi")
 func foo () {
   override func loadView() {
     super.loadView()

--- a/example/example.swift
+++ b/example/example.swift
@@ -266,3 +266,10 @@ let dict = [
     "fadsf",
   ],
 ]
+
+if #available(OSX 10.10.3, *) {
+    // Use APIs OS X 10.10.3 and onwards
+}
+if #available(watchOS 2, iOS 9.0, OSX 10.11, *) {
+    // APIs available to watchOS 2.0, iOS 9.0, OSX 10.11 and onwards
+}

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -124,7 +124,7 @@ syntax keyword swiftKeywords
 syntax keyword swiftAttributes
       \ @assignment
       \ @autoclosure
-      \ @availability
+      \ @available
       \ @convention
       \ @exported
       \ @IBAction
@@ -141,6 +141,8 @@ syntax keyword swiftAttributes
       \ @testable
       \ @UIApplicationMain
       \ @warn_unused_result
+
+syntax keyword swiftConditionalAttributes #available
 
 syntax keyword swiftStructure
       \ struct
@@ -184,6 +186,7 @@ highlight default link swiftBoolean Boolean
 highlight default link swiftOperator Operator
 highlight default link swiftKeywords Keyword
 highlight default link swiftAttributes PreProc
+highlight default link swiftConditionalAttributes PreProc
 highlight default link swiftStructure Structure
 highlight default link swiftType Type
 highlight default link swiftImports Include

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -142,7 +142,7 @@ syntax keyword swiftAttributes
       \ @UIApplicationMain
       \ @warn_unused_result
 
-syntax keyword swiftConditionalAttributes #available
+syntax keyword swiftConditionStatement #available
 
 syntax keyword swiftStructure
       \ struct
@@ -186,7 +186,7 @@ highlight default link swiftBoolean Boolean
 highlight default link swiftOperator Operator
 highlight default link swiftKeywords Keyword
 highlight default link swiftAttributes PreProc
-highlight default link swiftConditionalAttributes PreProc
+highlight default link swiftConditionStatement PreProc
 highlight default link swiftStructure Structure
 highlight default link swiftType Type
 highlight default link swiftImports Include

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -55,6 +55,8 @@ syntax match swiftOperator "\v\?\?"
 " Methods/Functions
 syntax match swiftMethod "\(\.\)\@<=\w\+\((\)\@="
 
+syntax match swiftAvailability "\v((iOS|OSX|watchOS)\s+\d+(\.\d+(.\d+)?)?\s*,\s*)+\*"
+syntax keyword swiftPlatforms OSX iOS watchOS contained containedin=swiftAvailability
 
 " Keywords {{{
 syntax keyword swiftKeywords
@@ -192,6 +194,9 @@ highlight default link swiftType Type
 highlight default link swiftImports Include
 highlight default link swiftPreprocessor PreProc
 highlight default link swiftMethod Function
+highlight default link swiftConditionStatement PreProc
+highlight default link swiftAvailability Normal
+highlight default link swiftPlatforms Keyword
 
 
 let b:current_syntax = "swift"

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -198,7 +198,7 @@ highlight default link swiftMethod Function
 
 highlight default link swiftConditionStatement PreProc
 highlight default link swiftAvailability Normal
-highlight default link swiftAvailabilityArg Special
+highlight default link swiftAvailabilityArg Normal
 highlight default link swiftPlatforms Keyword
 
 

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -55,8 +55,9 @@ syntax match swiftOperator "\v\?\?"
 " Methods/Functions
 syntax match swiftMethod "\(\.\)\@<=\w\+\((\)\@="
 
-syntax match swiftAvailability "\v((iOS|OSX|watchOS)\s+\d+(\.\d+(.\d+)?)?\s*,\s*)+\*"
-syntax keyword swiftPlatforms OSX iOS watchOS contained containedin=swiftAvailability
+syntax match swiftAvailability "\v((\*(\s*,\s*[a-zA-Z="0-9.]+)*)|(\w+\s+\d+(\.\d+(.\d+)?)?\s*,\s*)+\*)" contains=swiftString
+syntax keyword swiftPlatforms OSX iOS watchOS OSXApplicationExtension iOSApplicationExtension contained containedin=swiftAvailability
+syntax keyword swiftAvailabilityArg renamed unavailable introduced deprecated obsoleted message contained containedin=swiftAvailability
 
 " Keywords {{{
 syntax keyword swiftKeywords
@@ -194,8 +195,10 @@ highlight default link swiftType Type
 highlight default link swiftImports Include
 highlight default link swiftPreprocessor PreProc
 highlight default link swiftMethod Function
+
 highlight default link swiftConditionStatement PreProc
 highlight default link swiftAvailability Normal
+highlight default link swiftAvailabilityArg Special
 highlight default link swiftPlatforms Keyword
 
 


### PR DESCRIPTION
This adds the new (introduced in Swift 2) `@available` and `#available` attributes to the swift syntax file.

I chose to add this to the new `swiftConditionalAttribute` (since it's a conditional attribute that is used in `if`/`guard` statements) rather than the existing `swiftAttributes` (which are typically used to apply to functions/classes).

If you think that's wrong, I can easily update this.

Resolves #54 
