### PR TITLE
Skip brackets in comment

### DIFF
--- a/indent/swift.vim
+++ b/indent/swift.vim
@@ -84,10 +84,10 @@ function! SwiftIndent(lnum)
     elseif previous =~ "}.*{"
       return previousIndent + shiftwidth()
     elseif line =~ "}.*{"
-      let openingBracket = searchpair("{", "", "}", "bWn")
+      let openingBracket = searchpair("{", "", "}", "bWn", 's:IsComment()')
       return indent(openingBracket)
     elseif currentCloseBrackets > currentOpenBrackets
-      let openingBracket = searchpair("{", "", "}", "bWn")
+      let openingBracket = searchpair("{", "", "}", "bWn", 's:IsComment()')
       let bracketLine = getline(openingBracket)
 
       let numOpenParensBracketLine = s:NumberOfMatches("(", bracketLine)
@@ -113,7 +113,7 @@ function! SwiftIndent(lnum)
         endif
 
         if line =~ "}.*{"
-          let openingBracket = searchpair("{", "", "}", "bWn")
+          let openingBracket = searchpair("{", "", "}", "bWn", 's:IsComment()')
           return indent(openingBracket)
         endif
 
@@ -128,7 +128,7 @@ function! SwiftIndent(lnum)
       endif
 
       if currentCloseBrackets > 0
-        let openingBracket = searchpair("{", "", "}", "bWn")
+        let openingBracket = searchpair("{", "", "}", "bWn", 's:IsComment()')
         return indent(openingBracket)
       endif
 


### PR DESCRIPTION
I fixed indent issue. brackets in comment.
```swift
    override func viewDidLoad() {
        super.viewDidLoad()

        let skView = self.view as! SKView
        //        *this is commnet skip check bracket!* {
            let scene = GameScene(size: skView.bounds.size)
                // Configure the view.
                skView.showsFPS = true
                skView.showsNodeCount = true

                /* Sprite Kit applies additional optimizations to improve rendering performance */
                skView.ignoresSiblingOrder = true

                /* Set the scale mode to scale to fit the window */
                scene.scaleMode = .AspectFill

                skView.presentScene(scene)
        }
```
last line wrong indent.
I would expect it to be like this
```swift
    override func viewDidLoad() {
        super.viewDidLoad()

        let skView = self.view as! SKView
        //        *fix skip bracket in comment !* {
            let scene = GameScene(size: skView.bounds.size)
                // Configure the view.
                skView.showsFPS = true
                skView.showsNodeCount = true

                /* Sprite Kit applies additional optimizations to improve rendering performance */
                skView.ignoresSiblingOrder = true

                /* Set the scale mode to scale to fit the window */
                scene.scaleMode = .AspectFill

                skView.presentScene(scene)
    }
```
