### PR TITLE
add 'associatedtype' as a keyword

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -102,6 +102,7 @@ syntax keyword swiftAvailabilityArg renamed unavailable introduced deprecated ob
 " Keywords {{{
 syntax keyword swiftKeywords
       \ as
+      \ associatedtype
       \ atexit
       \ break
       \ case


### PR DESCRIPTION
This keyword is added in [SE-0011](https://github.com/apple/swift-evolution/blob/master/proposals/0011-replace-typealias-associated.md).