### PR TITLE
highlight Swift builtin debug identifiers

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -200,6 +200,16 @@ syntax keyword swiftStructure
       \ struct
       \ enum
 
+syntax keyword swiftDebugIdentifier
+      \ #column
+      \ #file
+      \ #function
+      \ #line
+      \ __COLUMN__
+      \ __FILE__
+      \ __FUNCTION__
+      \ __LINE__
+
 syntax region swiftTypeWrapper start="\v:\s*" skip="\s*,\s*$*\s*" end="$\|/"me=e-1 contains=ALLBUT,swiftInterpolatedWrapper transparent
 syntax region swiftGenericsWrapper start="\v\<" end="\v\>" contains=swiftType transparent oneline
 syntax region swiftLiteralWrapper start="\v\=\s*" skip="\v[^\[\]]\(\)" end="\v(\[\]|\(\))" contains=ALL transparent oneline
@@ -252,6 +262,7 @@ highlight default link swiftConditionStatement PreProc
 highlight default link swiftAvailability Normal
 highlight default link swiftAvailabilityArg Normal
 highlight default link swiftPlatforms Keyword
+highlight default link swiftDebugIdentifier PreProc
 
 " Force vim to sync at least x lines. This solves the multiline comment not
 " being highlighted issue


### PR DESCRIPTION
Highlight both pre- and post- [SE0028](https://github.com/apple/swift-evolution/blob/master/proposals/0028-modernizing-debug-identifiers.md) debug identifiers. I chose the keyword color, but any delineation would be a improvement.