### PR TITLE
Add syntax highlighting for type casts

### DIFF
--- a/example/example.swift
+++ b/example/example.swift
@@ -345,3 +345,5 @@ self.init(className: "Item", dictionary: [
     "link": item.link,
     "date": item.date,
     "summary": item.summary])
+
+XCAssertEqual(variables as NSDictionary, expectedVariables as NSDictionary, "\(template)")

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -102,7 +102,6 @@ syntax keyword swiftAvailabilityArg renamed unavailable introduced deprecated ob
 
 " Keywords {{{
 syntax keyword swiftKeywords
-      \ as
       \ associatedtype
       \ atexit
       \ break
@@ -133,7 +132,6 @@ syntax keyword swiftKeywords
       \ init
       \ inout
       \ internal
-      \ is
       \ lazy
       \ let
       \ mutating
@@ -214,13 +212,14 @@ syntax keyword swiftDebugIdentifier
 syntax keyword swiftLineDirective #setline
 
 syntax region swiftTypeWrapper start="\v:\s*" skip="\s*,\s*$*\s*" end="$\|/"me=e-1 contains=ALLBUT,swiftInterpolatedWrapper transparent
+syntax region swiftTypeCastWrapper start="\(as\|is\)\(!\|?\)\=\s\+" end="\v(\s|$|\{)" contains=swiftType,swiftCastKeyword keepend transparent oneline
 syntax region swiftGenericsWrapper start="\v\<" end="\v\>" contains=swiftType transparent oneline
 syntax region swiftLiteralWrapper start="\v\=\s*" skip="\v[^\[\]]\(\)" end="\v(\[\]|\(\))" contains=ALL transparent oneline
 syntax region swiftReturnWrapper start="\v-\>\s*" end="\v(\{|$)" contains=swiftType transparent oneline
-syntax match swiftType "\v<\u\w*" contained containedin=swiftGenericsWrapper,swiftTypeWrapper,swiftLiteralWrapper,swiftGenericsWrapper
+syntax match swiftType "\v<\u\w*" contained containedin=swiftTypeWrapper,swiftLiteralWrapper,swiftGenericsWrapper,swiftTypeCastWrapper
 
 syntax keyword swiftImports import
-
+syntax keyword swiftCastKeyword is as contained
 
 " 'preprocesor' stuff
 syntax keyword swiftPreprocessor
@@ -251,6 +250,7 @@ highlight default link swiftNumber Number
 highlight default link swiftBoolean Boolean
 
 highlight default link swiftOperator Operator
+highlight default link swiftCastKeyword Keyword
 highlight default link swiftKeywords Keyword
 highlight default link swiftEscapedReservedWord Normal
 highlight default link swiftClosureArgument Operator


### PR DESCRIPTION
This commit separates `as` and `is` into their own keyword syntax,
and contains them in a new syntax region for type casts.

Also removes an extraneous `swiftGenericsWrapper` in the `swiftType`
syntax match.

Fixes #48: 

Old:

![f54043ce-3a32-11e5-8cf7-97e81c27588f](https://cloud.githubusercontent.com/assets/1159146/14770174/cd9e1072-0a1f-11e6-90cc-d39c99860ce8.png)

New:
<img width="651" alt="screen shot 2016-04-24 at 12 57 09" src="https://cloud.githubusercontent.com/assets/1159146/14770171/bd0747ec-0a1f-11e6-843d-7ae6d5160138.png">
