### PR TITLE
Force swift filetype for `*.swift` files

### DIFF
--- a/ftdetect/swift.vim
+++ b/ftdetect/swift.vim
@@ -1,4 +1,4 @@
-autocmd BufNewFile,BufRead *.swift setfiletype swift
+autocmd BufNewFile,BufRead *.swift set filetype=swift
 autocmd BufRead * call s:Swift()
 function! s:Swift()
   if !empty(&filetype)


### PR DESCRIPTION
This fixes an issue where files would occasionally be interpreted as
`conf` files