### PR TITLE
Add match pattern underscore to hex, binary, octal literals

### DIFF
--- a/example/example.swift
+++ b/example/example.swift
@@ -58,14 +58,17 @@ if foo {
 
 0xa2ef // hex
 0x123P432
+0xa_2ef // hex with underscore
 0x13p-43
 0x13r-43
 0x213zdf // broken hex
 
 0b10101 // binary
+0b1010_1 // binary with underscore
 0b1234 // broken binary
 
 0o567 // octal
+0o56_7 // octal with underscore
 0o5689 // broken octal
 
 1_000_000                // underscore separated million

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -62,9 +62,9 @@ syntax match swiftNumber "\v<\d+>"
 syntax match swiftNumber "\v<(\d+_+)+\d+(\.\d+(_+\d+)*)?>"
 syntax match swiftNumber "\v<\d+\.\d+>"
 syntax match swiftNumber "\v<\d*\.?\d+([Ee]-?)?\d+>"
-syntax match swiftNumber "\v<0x\x+([Pp]-?)?\x+>"
-syntax match swiftNumber "\v<0b[01]+>"
-syntax match swiftNumber "\v<0o\o+>"
+syntax match swiftNumber "\v<0x[[:xdigit:]_]+([Pp]-?)?\x+>"
+syntax match swiftNumber "\v<0b[01_]+>"
+syntax match swiftNumber "\v<0o[0-7_]+>"
 
 " BOOLs
 syntax keyword swiftBoolean


### PR DESCRIPTION
Hi, I found a little incorrect in integer literals.

The hex-literal, binary-literal, octal-literal can use underscore. Please see [Integer Literals in Apple document](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html)

and I added an example.

![2016-05-08 16 38 07](https://cloud.githubusercontent.com/assets/221802/15096626/d0b031fa-153c-11e6-9c02-fb784c2d8f14.png)

This plugin is very helpful for me. Thanks!!