### PR TITLE
Add keywords and examples for custom operator symbols

### DIFF
--- a/example/example.swift
+++ b/example/example.swift
@@ -133,6 +133,23 @@ let b = 50 /= 20
 ||=
 ~=
 
+// Custom Operators
+infix operator ～ {
+    precedence 20      // Define precedence
+    associativity none // Define associativity
+}
+
+func ～(n: Int, w: Int) -> String {
+    var str = String(n)
+    let pad = w - str.characters.count
+    if pad > 0 {
+        str = String(count: pad,
+                repeatedValue: Character(" ")) + str
+    }
+
+    return str
+}
+
 true
 false
 

--- a/example/example.swift
+++ b/example/example.swift
@@ -139,17 +139,6 @@ infix operator ～ {
     associativity none // Define associativity
 }
 
-func ～(n: Int, w: Int) -> String {
-    var str = String(n)
-    let pad = w - str.characters.count
-    if pad > 0 {
-        str = String(count: pad,
-                repeatedValue: Character(" ")) + str
-    }
-
-    return str
-}
-
 true
 false
 

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -103,6 +103,7 @@ syntax keyword swiftAvailabilityArg renamed unavailable introduced deprecated ob
 " Keywords {{{
 syntax keyword swiftKeywords
       \ associatedtype
+      \ associativity
       \ atexit
       \ break
       \ case
@@ -141,6 +142,7 @@ syntax keyword swiftKeywords
       \ optional
       \ override
       \ postfix
+      \ precedence
       \ prefix
       \ private
       \ protocol


### PR DESCRIPTION
Hi, I add keywords ( `precedence ` , `associativity` ) for define  custom operator symbols.

Screenshot:
![custom-operators-screenshot](https://cloud.githubusercontent.com/assets/221802/19210407/204ba328-8d5d-11e6-8202-81d2da787776.png)

See also:
https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Declarations.html#//apple_ref/doc/uid/TP40014097-CH34-ID380

This syntax plugin is very cool. Thanks for maintaining.