### PR TITLE
Prevent swiftComment match from hiding region end

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -241,7 +241,7 @@ syntax keyword swiftPreprocessor
 syntax match swiftComment "\v\/\/.*$"
       \ contains=swiftTodos,swiftDocString,swiftMarker,@Spell oneline
 syntax region swiftComment start="/\*" end="\*/"
-      \ contains=swiftTodos,swiftDocString,swiftMarker,swiftComment,@Spell fold
+      \ contains=swiftTodos,swiftDocString,swiftMarker,@Spell fold
 
 
 " Set highlights


### PR DESCRIPTION
When a block style comment contains `//` on the same line as its end mark, it was causing the region to extend to the end of file.