### PR TITLE
indent: fix regex in IsCommentLine

### DIFF
--- a/indent/swift.vim
+++ b/indent/swift.vim
@@ -49,7 +49,7 @@ endfunction
 
 function! s:IsCommentLine(lnum)
     return synIDattr(synID(a:lnum,
-          \     match(getline(a:lnum), "\S") + 1, 0), "name")
+          \     match(getline(a:lnum), "\\S") + 1, 0), "name")
           \ ==# "swiftComment"
 endfunction
 


### PR DESCRIPTION
backslashes need to be escaped:

```vim
echo match("test", "\S") " -> -1
echo match("test", "\\S") " -> 0
```

this may fix #112