### PR TITLE
indent: fix indenting within parens

### DIFF
--- a/indent/swift.vim
+++ b/indent/swift.vim
@@ -225,8 +225,8 @@ function! SwiftIndent(...)
   if numOpenParens > 0
     let savePosition = getcurpos()
     " Must be at EOL because open paren has to be above (left of) the cursor
-    call cursor(previousNum, col("$"))
-    let previousParen = searchpair("(", "", ")", "bWn", "s:IsExcludedFromIndent()")
+    call cursor(previousNum, [previousNum, col("$")])
+    let previousParen = searchpair("(", "", ")", "cbWn", "s:IsExcludedFromIndent()")
     call setpos(".", savePosition)
     return indent(previousParen) + shiftwidth()
   endif


### PR DESCRIPTION
I like to sometimes split function parameters across multiple lines, and was getting an odd result from this indentation file:

```swift
class Yodeling {

    public func yodel(
   words: String,
   duration: Double
        )
    {
        fatalError()
    }
}
```

while debugging I found that the call `cursor(previousNum, col("$"))` wasn't going to the real EOL because it uses the $-column of the current line, and that the open paren at the end of line 3 was being missed because `searchpair` only matches at the current cursor position while searching backwards if the `c` flag is set.

new indentation:

```swift
class Yodeling {

    public func yodel(
        words: String,
        duration: Double
        )
    {
        fatalError()
    }
}
```

I would like to be able to get the close paren onto the same indent as its open paren, but I haven't quite figured that one out yet.