### PR TITLE
Fix debug identifiers not highlighting in interpolated strings

### DIFF
--- a/example/example.swift
+++ b/example/example.swift
@@ -359,3 +359,4 @@ self.init(className: "Item", dictionary: [
     "summary": item.summary])
 
 XCAssertEqual(variables as NSDictionary, expectedVariables as NSDictionary, "\(template)")
+print("Called from \(#file)\(#line) in \(__COLUMN__)")

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -54,8 +54,8 @@ delfunction s:CommentKeywordMatch
 " Literals
 " Strings
 syntax region swiftString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=swiftInterpolatedWrapper oneline
-syntax region swiftInterpolatedWrapper start="\v[^\\]\zs\\\(\s*" end="\v\s*\)" contained containedin=swiftString contains=swiftInterpolatedString,swiftString oneline
-syntax match swiftInterpolatedString "\v\w+(\(\))?" contained containedin=swiftInterpolatedWrapper oneline
+syntax region swiftInterpolatedWrapper start="\v[^\\]\zs\\\(\s*" end="\v\s*\)" contained containedin=swiftString contains=swiftInterpolatedString,swiftString,swiftDebugIdentifier oneline
+syntax match swiftInterpolatedString "\v\w+(\(\))?" contained containedin=swiftInterpolatedWrapper
 
 " Numbers
 syntax match swiftNumber "\v<\d+>"
@@ -209,16 +209,7 @@ syntax keyword swiftStructure
       \ struct
       \ enum
 
-syntax keyword swiftDebugIdentifier
-      \ #column
-      \ #file
-      \ #function
-      \ #line
-      \ __COLUMN__
-      \ __FILE__
-      \ __FUNCTION__
-      \ __LINE__
-
+syntax match swiftDebugIdentifier "#column\|#file\|#function\|#line\|__COLUMN__\|__FILE__\|__FUNCTION__\|__LINE__"
 syntax keyword swiftLineDirective #setline
 
 syntax region swiftTypeWrapper start="\v:\s*" skip="\s*,\s*$*\s*" end="$\|/"me=e-1 contains=ALLBUT,swiftInterpolatedWrapper transparent


### PR DESCRIPTION
This uses a syntax match for swiftDebugIdentifier instead of them being
keywords.

Resolves #107 

Before:
<img width="337" alt="before" src="https://user-images.githubusercontent.com/1159146/29651585-4c3e38a2-8856-11e7-963f-d40358a08946.png">

After:

<img width="332" alt="after" src="https://user-images.githubusercontent.com/1159146/29651591-520991e6-8856-11e7-91aa-1904335a14bf.png">

