### PR TITLE
Ensure swiftTypeWrapper only wraps types in its own matchgroup

### DIFF
--- a/example/example.swift
+++ b/example/example.swift
@@ -360,3 +360,12 @@ self.init(className: "Item", dictionary: [
     "summary": item.summary])
 
 XCAssertEqual(variables as NSDictionary, expectedVariables as NSDictionary, "\(template)")
+
+NSWorkspace.sharedWorkspace().notificationCenter.addObserver(
+    self, selector: #selector(self.activeApplicationChanged(_:)),
+    name: NSWorkspaceDidActivateApplicationNotification, object: nil
+)
+
+public func find(closure: @noescape Element throws -> Bool) rethrows -> Element? {
+
+}

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -220,7 +220,7 @@ syntax keyword swiftDebugIdentifier
 
 syntax keyword swiftLineDirective #setline
 
-syntax region swiftTypeWrapper start="\v:\s*" skip="\s*,\s*$*\s*" end="$\|/"me=e-1 contains=ALLBUT,swiftInterpolatedWrapper transparent
+syntax region swiftTypeWrapper start=":\s*\(\.\)\@!\<\u" skip="\s*,\s*$*\s*" end="$\|/"me=e-1 contains=ALLBUT,swiftInterpolatedWrapper transparent
 syntax region swiftTypeCastWrapper start="\(as\|is\)\(!\|?\)\=\s\+" end="\v(\s|$|\{)" contains=swiftType,swiftCastKeyword keepend transparent oneline
 syntax region swiftGenericsWrapper start="\v\<" end="\v\>" contains=swiftType transparent oneline
 syntax region swiftLiteralWrapper start="\v\=\s*" skip="\v[^\[\]]\(\)" end="\v(\[\]|\(\))" contains=ALL transparent oneline


### PR DESCRIPTION
Enum members, numbers, other literals like string will be highlighted
separately as part of their own matchgroup.

The result is that this:

fixes #93
fixes #90
fixes #89