### PR TITLE
Remove `Last Modified` comment

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -1,7 +1,6 @@
 " File: swift.vim
 " Author: Keith Smiley
 " Description: Runtime files for Swift
-" Last Modified: June 15, 2014
 
 if exists("b:current_syntax")
   finish


### PR DESCRIPTION
The comment isn't being kept up to date, so it ends up misleading readers into thinking the file hasn't been updated in years. I think it makes sense to remove it, git's log system works better to date this