### PR TITLE
fix: broken ALE linter syntax

### DIFF
--- a/ale_linters/swift/swiftpm.vim
+++ b/ale_linters/swift/swiftpm.vim
@@ -62,8 +62,8 @@ endfunction
 
 call ale#linter#Define('swift', {
       \ 'name': 'swiftpm',
-      \ 'executable_callback': 'ale_linters#swift#swiftpm#GetExecutable',
-      \ 'command_callback': 'ale_linters#swift#swiftpm#GetCommand',
+      \ 'executable': 'ale_linters#swift#swiftpm#GetExecutable',
+      \ 'command': 'ale_linters#swift#swiftpm#GetCommand',
       \ 'callback': 'ale_linters#swift#swiftpm#Handle',
       \ 'lint_file': 1,
     \ })


### PR DESCRIPTION
`call ale#linter#Define` renamed parameters:
> executable_callback -> executable
> command_callback -> command

Fixes #129.