### PR TITLE
Add upcoming concurrency keywords

### DIFF
--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -105,6 +105,7 @@ syntax keyword swiftKeywords
       \ associatedtype
       \ associativity
       \ atexit
+      \ await
       \ break
       \ case
       \ catch
@@ -170,6 +171,7 @@ syntax keyword swiftKeywords
       \ willSet
 
 syntax keyword swiftDefinitionModifier
+      \ async
       \ rethrows
       \ throws
 

--- a/syntax/swift.vim
+++ b/syntax/swift.vim
@@ -219,8 +219,9 @@ syntax keyword swiftAttributes
 syntax keyword swiftConditionStatement #available
 
 syntax keyword swiftStructure
-      \ struct
+      \ actor
       \ enum
+      \ struct
 
 syntax keyword swiftDebugIdentifier
       \ #column


### PR DESCRIPTION
`async`, `await`, `actor` are coming in Swift 5.5 (probably in beta after WWDC21).

[SE-0296](https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md)
[SE-0306](https://github.com/apple/swift-evolution/blob/main/proposals/0306-actors.md)