### PR TITLE
Fix SwiftUI indentation issues

### DIFF
--- a/example/MainViewController.swift
+++ b/example/MainViewController.swift
@@ -54,13 +54,13 @@ class MainViewController: UIViewController, UITableViewDataSource {
                     self.tableView.reloadSections(NSIndexSet(index: 0), withRowAnimation: .Fade)
                     self.refreshControl.endRefreshing()
                     UIApplication.sharedApplication().networkActivityIndicatorVisible = false
-                })
+                               })
             } else {
                 println("Could not fetch posts!")
                 self.refreshControl.endRefreshing()
                 UIApplication.sharedApplication().networkActivityIndicatorVisible = false;
             }
-        })
+                                                      })
     }
 
     func stylePostCellAsRead(cell: UITableViewCell) {

--- a/example/SwiftUIView.swift
+++ b/example/SwiftUIView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import PlaygroundSupport
+
+struct ExampleView: View {
+    @State var isShowingSheet = false
+
+    var body: some View {
+        VStack {
+            Text("Hello, World!")
+            // comment
+                .font(.caption)
+                .monospaced()
+            // red font
+                .foregroundStyle(.red)
+            Button(action: { print("clicked") }) {
+                Text("click me")
+            }
+            .buttonStyle(.bordered)
+
+            Button(action: { isShowingSheet = true }) {
+                Text("show sheet")
+            }
+            Text("sample")
+                .overlay {
+                    Circle()
+                        .fill(.gray.opacity(0.25))
+                }
+                .lineLimit(2)
+            Text("sample2")
+            HStack {
+                ForEach(0...5, id: \.self) { n in
+                    if n % 2 == 0 {
+                        Text(n.description)
+                            .foregroundStyle(.green)
+                    }
+                    else {
+                        Text(n.description)
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .frame(width: 200, height: 400)
+        .sheet(isPresented: $isShowingSheet) {
+            Text("sheet")
+        }
+    }
+}
+
+PlaygroundPage.current.setLiveView(ExampleView())

--- a/indent/swift.vim
+++ b/indent/swift.vim
@@ -187,6 +187,16 @@ function! SwiftIndent(...)
       let openingParen = searchpair("(", "", ")", "bWn", "s:IsExcludedFromIndent()")
       call cursor(line, column)
       return indent(openingParen)
+    elseif line =~ '^\s*\.' && previous !~ '^\s*\.' && numOpenParens > 0
+      return previousIndent + shiftwidth()
+    elseif previous =~ '^\s*\.'
+      if s:IsCommentLine(clnum) != 0
+        return previousIndent - shiftwidth()
+      elseif line =~ '^\s*\.'
+        return previousIndent
+      else
+        return previousIndent - shiftwidth()
+      endif
     else
       " - Current line is blank, and the user presses 'o'
       return previousIndent

--- a/indent/swift.vim
+++ b/indent/swift.vim
@@ -147,6 +147,9 @@ function! SwiftIndent(...)
         call cursor(line, column)
         return openingParenCol
       endif
+      if numOpenParensBracketLine == 0 && numCloseParensBracketLine == 0
+        return indent(openingBracket) + shiftwidth()
+      endif
 
       return indent(openingBracket)
     elseif currentCloseBrackets > currentOpenBrackets


### PR DESCRIPTION
Hi. Thank you for developing such useful plugin. It helps me everyday!

I fixed some issues with SwiftUI indentation. (includes issue #152)

## View Modifiers

was:

```swift
NavigationStack {
    CoolView()
    .padding(10)
}
.padding(12)
```

now:

```swift
NavigationStack {
    CoolView()
        .padding(10)
}
.padding(12)
```

## ViewBuilders

was:

```swift
VStack {
    Text("Hello, World!")
Button(action: { print("clicked") }) {
    Text("click me")
}
}
```

now:

```swift
VStack {
    Text("Hello, World!")
    Button(action: { print("clicked") }) {
        Text("click me")
    }
}
```

## tests

* I applied auto-indentation to `example/example.swift` and `example/MainViewController.swift` and confirmed that this change will cause no side effects.
* I created new example file `SwiftUIView.swift` and confirmed that the indentation with this plugin and Xcode are same.

## appendix

I fixed `example/MainViewController.swift` first because indentation of this file was not consistent with this plugin's indentation result.