### PR TITLE
Fix closing bracket indentation issue

### DIFF
--- a/example/example.swift
+++ b/example/example.swift
@@ -389,3 +389,34 @@ A.b().application(
 
 A.application(b(),
               application, didFinishLaunchingWithOptions: launchOptions)
+
+struct Foo {
+    func callee(delegate1: () -> Void, delegate2: () -> Void) {
+        delegate1()
+        delegate2()
+    }
+    func caller1() {
+        callee(delegate1: {
+                   print("caller1 delegate1")
+               }) {
+                   print("caller1 delegate2")
+        }
+    }
+    func caller2() {
+        callee(delegate1: {
+                   print("caller1 delegate1")
+               }, delegate2: {
+                   print("caller1 delegate2")
+               })
+    }
+    func caller3() {
+        callee(delegate1: {
+                   print("caller1 delegate1")
+               }, delegate2: {
+                   print([0, 1].map {
+                             $0 + 1
+                         })
+                   print("caller1 delegate2")
+               })
+    }
+}


### PR DESCRIPTION
I fixed the issue about closing bracket indentation.

This fix doesn't address the issue #155.
(During inspection, I found this issue.)

Was:

```swift
struct Foo {
    func callee(delegate1: () -> Void, delegate2: () -> Void) {
        delegate1()
        delegate2()
    }
    func caller1() {
        callee(delegate1: {
                   print("caller1 delegate1")
               }) {
                   print("caller1 delegate2")
}
    }
    func caller2() {
        callee(delegate1: {
                   print("caller1 delegate1")
               }, delegate2: {
                   print("caller1 delegate2")
               })
    }
    func caller3() {
        callee(delegate1: {
                   print("caller1 delegate1")
               }, delegate2: {
                   print([0, 1].map {
                             $0 + 1
                         })
                   print("caller1 delegate2")
               })
    }
}
```

Now:

```swift
struct Foo {
    func callee(delegate1: () -> Void, delegate2: () -> Void) {
        delegate1()
        delegate2()
    }
    func caller1() {
        callee(delegate1: {
                   print("caller1 delegate1")
               }) {
                   print("caller1 delegate2")
        }
    }
    func caller2() {
        callee(delegate1: {
                   print("caller1 delegate1")
               }, delegate2: {
                   print("caller1 delegate2")
               })
    }
    func caller3() {
        callee(delegate1: {
                   print("caller1 delegate1")
               }, delegate2: {
                   print([0, 1].map {
                             $0 + 1
                         })
                   print("caller1 delegate2")
               })
    }
}
```


```diff
--- was.txt     2025-02-08 00:13:35
+++ now.txt     2025-02-08 00:13:22
@@ -8,7 +8,7 @@
                    print("caller1 delegate1")
                }) {
                    print("caller1 delegate2")
-}
+        }
     }
     func caller2() {
         callee(delegate1: {
```

## Tests

* I added the reproduction code same as above example to `example/example.swift` and verified that auto indentation works expectedly.
* I applied auto indentation for all `example/*`, and verified there are no side effects.

## Appendix

I found the operations for searching opening paren were performed at multiple part and can be shared.
So I created a new function `s:SearchOpeningParenPos()` for that purpose.


