### PR TITLE
Add regression test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Run Test
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run test
+        run: ./run_test.sh

--- a/autoindent.vim
+++ b/autoindent.vim
@@ -1,0 +1,23 @@
+if empty($OUTPUT_FILE)
+  echom "Error: Environment variable OUTPUT_FILE is not set."
+  cquit! 1
+endif
+
+set nocompatible
+set runtimepath^=$PWD
+filetype plugin indent on
+
+syntax on
+augroup swiftIndent
+  autocmd!
+  autocmd BufRead,BufNewFile *.swift setlocal shiftwidth=4 expandtab
+augroup END
+
+" Apply autoindent, save and quit.
+function! s:RemoveWhitespaceAndReindent()
+  silent %s/^\s\+//
+  normal gg=G
+  execute 'write ' . fnameescape($OUTPUT_FILE)
+  quit!
+endfunction
+autocmd BufReadPost * call s:RemoveWhitespaceAndReindent()

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euo pipefail
+
+tempdir=$(mktemp -d)
+trap cleanup EXIT
+
+cleanup() {
+  rm -r "$tempdir"
+}
+
+for example_file in example/*.swift; do
+  autoindented_file="$tempdir/${example_file##*/}"
+  OUTPUT_FILE="$autoindented_file" vim -u autoindent.vim "$example_file"
+  diff -u --color=auto "$example_file" "$autoindented_file"
+done
+
+echo "test passed!"


### PR DESCRIPTION
I added a script for regression testing.

This script automate applying auto-indentation to all `example/*.swift` with using vim, and show diffs with `example/*.swift`.

If no diffs, it prints just `test passed!`
If diffs exist, it prints the diffs.

## Example

Has no diffs:

```
$ ./run_test.sh
test passed!
```

Has Diffs:

```
$ ./run_test.sh
--- example/example.swift       2025-02-08 02:50:38
+++ /var/folders/06/rhw595nj6vv0jffs7vl2ndwh0000gn/T/tmp.lJXGDoGK5r/example.swift       2025-02-08 02:52:18
@@ -9,7 +9,7 @@
 // If statements so the indented comments are valid
 if foo {
     /* this is an indented comment */
-  }
+}

 if foo {
     /* this is a multi level indented comment /* you know */ */
```

## Continuous testing

I also added GitHub Actions workflow to ensure there is no regression in future PRs.

* [test success example](https://github.com/ottijp/swift.vim/actions/runs/13205647457/job/36868071634)
* [test failure example](https://github.com/ottijp/swift.vim/actions/runs/13205667225/job/36868135965)