### PR TITLE
Fixed indentation in block which is different from Xcode's

### DIFF
--- a/example/MainViewController.swift
+++ b/example/MainViewController.swift
@@ -54,13 +54,13 @@ class MainViewController: UIViewController, UITableViewDataSource {
                     self.tableView.reloadSections(NSIndexSet(index: 0), withRowAnimation: .Fade)
                     self.refreshControl.endRefreshing()
                     UIApplication.sharedApplication().networkActivityIndicatorVisible = false
-                               })
+                })
             } else {
                 println("Could not fetch posts!")
                 self.refreshControl.endRefreshing()
                 UIApplication.sharedApplication().networkActivityIndicatorVisible = false;
             }
-                                                      })
+        })
     }
 
     func stylePostCellAsRead(cell: UITableViewCell) {

--- a/example/SwiftUIView.swift
+++ b/example/SwiftUIView.swift
@@ -3,6 +3,7 @@ import PlaygroundSupport
 
 struct ExampleView: View {
     @State var isShowingSheet = false
+    @State var isShowingSheet2 = false
 
     var body: some View {
         VStack {
@@ -38,11 +39,23 @@ struct ExampleView: View {
                     }
                 }
             }
+            Button(action: {
+                print("clicked")
+                isShowingSheet2 = true
+            }) {
+                Text("click me")
+            }
+            .buttonStyle(.bordered)
         }
         .padding(12)
         .frame(width: 200, height: 400)
         .sheet(isPresented: $isShowingSheet) {
             Text("sheet")
+        }
+        .sheet(isPresented: Binding(get: { isShowingSheet2 },
+                                    set: { v in isShowingSheet2 = v }
+                                   )) {
+            Text("sheet2")
         }
     }
 }
@@ -119,6 +132,6 @@ struct ViewModifierPatternView: View {
 }
 
 PlaygroundPage.current.setLiveView(VStack {
-                                       ViewModifierPatternView()
-                                       ExampleView()
-                                   })
+    ViewModifierPatternView()
+    ExampleView()
+})

--- a/example/example.swift
+++ b/example/example.swift
@@ -353,10 +353,10 @@ let data = NSData(contentsOfFile: path) else
 }
 
 UIView.animateWithDuration(duration, delay: 0, usingSpringWithDamping: 0.8, initialSpringVelocity: 0, options: .CurveEaseInOut, animations: {
-                               view.backgroundColor = UIColor.redColor()
-                           }, completion: { finished in
-                               print("indent?")
-                           })
+    view.backgroundColor = UIColor.redColor()
+}, completion: { finished in
+    print("indent?")
+})
 
 // Indent last line should hold
 self.init(className: "Item", dictionary: [
@@ -378,11 +378,11 @@ public func find(closure: @noescape Element throws -> Bool) rethrows -> Element?
 }
 
 UIView.animate(withDuration: 0.2, animations: {
-                   self.foo.alpha = 1.0
-                   self.bar.alpha = 1.0
-               }, completion: { _ in
-                   completion()
-               })
+    self.foo.alpha = 1.0
+    self.bar.alpha = 1.0
+}, completion: { _ in
+    completion()
+})
 
 A.b().application(
     application, didFinishLaunchingWithOptions: launchOptions)
@@ -397,26 +397,48 @@ struct Foo {
     }
     func caller1() {
         callee(delegate1: {
-                   print("caller1 delegate1")
-               }) {
-                   print("caller1 delegate2")
+            print("caller1 delegate1")
+        }) {
+            print("caller1 delegate2")
         }
     }
     func caller2() {
         callee(delegate1: {
-                   print("caller1 delegate1")
-               }, delegate2: {
-                   print("caller1 delegate2")
-               })
+            print("caller1 delegate1")
+        }, delegate2: {
+            print("caller1 delegate2")
+        })
     }
     func caller3() {
         callee(delegate1: {
-                   print("caller1 delegate1")
-               }, delegate2: {
-                   print([0, 1].map {
-                             $0 + 1
-                         })
-                   print("caller1 delegate2")
-               })
+            print("caller1 delegate1")
+        }, delegate2: {
+            print([0, 1].map {
+                $0 + 1
+            })
+            print("caller1 delegate2")
+        })
     }
 }
+
+struct Bar {
+    func f(title: String, delegate: (Int) -> Void) {
+        print(title)
+        delegate(42)
+    }
+}
+
+Bar().f(
+    title: "the title"
+) { n in
+    print("n")
+}
+
+func createDelegate() -> ((Int) -> Void) {
+    return { n in
+        print("n")
+    }
+}
+
+Bar().f(title: "the title", delegate: createDelegate(
+))


### PR DESCRIPTION
I fixed the issue #155.

I modified some existing `example/*.swfit` to match Xcode's style.
In addition, I applied auto-indentation to some swift files in my project and veried they're exactly the same as Xcode's formatting.

Was:

```swift
VStack {
    Button(action: {
               print("clicked")
               isShowingSheet2 = true
           }) {
               Text("click me")
    }
    .buttonStyle(.bordered)
}
.padding(12)
.frame(width: 200, height: 400)
.sheet(isPresented: Binding(get: { isShowingSheet2 },
                            set: { v in isShowingSheet2 = v }
                            ) {
              Text("sheet2")
}
)
```

Now:

```swift
VStack {
    Button(action: {
        print("clicked")
        isShowingSheet2 = true
    }) {
        Text("click me")
    }
    .buttonStyle(.bordered)
}
.padding(12)
.frame(width: 200, height: 400)
.sheet(isPresented: Binding(get: { isShowingSheet2 },
                            set: { v in isShowingSheet2 = v }
                           ) {
    Text("sheet2")
}
)
```

Diff:

```diff
--- was.txt     2025-02-11 21:24:53
+++ now.txt     2025-02-11 21:24:59
@@ -1,9 +1,9 @@
 VStack {
     Button(action: {
-               print("clicked")
-               isShowingSheet2 = true
-           }) {
-               Text("click me")
+        print("clicked")
+        isShowingSheet2 = true
+    }) {
+        Text("click me")
     }
     .buttonStyle(.bordered)
 }
@@ -11,7 +11,7 @@
 .frame(width: 200, height: 400)
 .sheet(isPresented: Binding(get: { isShowingSheet2 },
                             set: { v in isShowingSheet2 = v }
-                            ) {
-              Text("sheet2")
+                           ) {
+    Text("sheet2")
 }
 )
```
